### PR TITLE
Add more plotting features

### DIFF
--- a/ush/plotting/default_options.yaml
+++ b/ush/plotting/default_options.yaml
@@ -122,6 +122,15 @@ plot:
   vmin: null
   vmax: null
 
+  # Settings for plotting coastlines. To disable coastlines, specify "coastlines:" with no options
+  coastlines:
+    # Arguments are documented in the matplotlib documentation:
+    # https://scitools.org.uk/cartopy/docs/v0.15/matplotlib/geoaxes.html#cartopy.mpl.geoaxes.GeoAxes.coastlines
+
+    color: 'black'
+    resolution: '10m'
+    linewidth: 0.5
+
   # Settings for the plot's color bar
   colorbar:
     # orientation:

--- a/ush/plotting/default_options.yaml
+++ b/ush/plotting/default_options.yaml
@@ -122,13 +122,17 @@ plot:
   vmin: null
   vmax: null
 
+  # Settings for plotting political boundaries. To disable political boundaries, specify "boundaries:" with no options
+  boundaries:
+    detail: 0
+
   # Settings for plotting coastlines. To disable coastlines, specify "coastlines:" with no options
   coastlines:
     # Arguments are documented in the matplotlib documentation:
     # https://scitools.org.uk/cartopy/docs/v0.15/matplotlib/geoaxes.html#cartopy.mpl.geoaxes.GeoAxes.coastlines
 
     color: 'black'
-    resolution: '10m'
+    scale: '10m'
     linewidth: 0.5
 
   # Settings for the plot's color bar

--- a/ush/plotting/default_options.yaml
+++ b/ush/plotting/default_options.yaml
@@ -89,7 +89,10 @@ plot:
   # 
   # figwidth:
   # Image width in inches
-
+  # 
+  # vmin, vmax:
+  # By default the color range will be scaled to the max/min values of the plotted data. To use a custom range,
+  # set vmin and/or vmax
 
   # NOTE: for text fields such as filename, title, etc., some helpful variables are provided that
   # you can reference in the text string that will be substituted in the final output:
@@ -115,6 +118,9 @@ plot:
   figheight: 4
   figwidth: 8
   periodic_bdy: False
+
+  vmin: null
+  vmax: null
 
   # Settings for the plot's color bar
   colorbar:

--- a/ush/plotting/default_options.yaml
+++ b/ush/plotting/default_options.yaml
@@ -132,13 +132,13 @@ plot:
 
   # Settings for plotting coastlines. To disable coastlines, specify "coastlines:" with no options
   coastlines:
-    # Arguments are documented in the matplotlib documentation:
-    # https://scitools.org.uk/cartopy/docs/v0.15/matplotlib/geoaxes.html#cartopy.mpl.geoaxes.GeoAxes.coastlines
-
+    # Scale is the resolution of the plotted boundary dataset. Options are 110m, 50m, and 10m.
+    scale: '10m'
+    # Most standard Matplotlib arguments for shapes will work here, but I haven't figured out good documentation on which.
+    # The ones listed here work, but likely a lot more customization can happen here.
     color: 'black'
     facecolor: 'none'
     linewidth: 0.5
-    scale: '10m'
 
   # Settings for the plot's color bar
   colorbar:

--- a/ush/plotting/default_options.yaml
+++ b/ush/plotting/default_options.yaml
@@ -125,8 +125,10 @@ plot:
   # Settings for plotting political boundaries. To disable political boundaries, specify "boundaries:" with no options
   boundaries:
     # Level of political boundaries to plot. Level 0 is national boundaries, Level 1 is sub-national boundaries (e.g.
-    # states, provinces, etc.), Level 2 is county boundaries (US only)
+    # states, provinces, etc.), Level 2 is county boundaries (US only); counties require 10m scale
     detail: 0
+    # Scale is the resolution of the plotted boundary dataset. Options are 110m, 50m, and 10m.
+    scale: 50m
 
   # Settings for plotting coastlines. To disable coastlines, specify "coastlines:" with no options
   coastlines:

--- a/ush/plotting/default_options.yaml
+++ b/ush/plotting/default_options.yaml
@@ -124,6 +124,8 @@ plot:
 
   # Settings for plotting political boundaries. To disable political boundaries, specify "boundaries:" with no options
   boundaries:
+    # Level of political boundaries to plot. Level 0 is national boundaries, Level 1 is sub-national boundaries (e.g.
+    # states, provinces, etc.), Level 2 is county boundaries (US only)
     detail: 0
 
   # Settings for plotting coastlines. To disable coastlines, specify "coastlines:" with no options
@@ -132,8 +134,9 @@ plot:
     # https://scitools.org.uk/cartopy/docs/v0.15/matplotlib/geoaxes.html#cartopy.mpl.geoaxes.GeoAxes.coastlines
 
     color: 'black'
-    scale: '10m'
+    facecolor: 'none'
     linewidth: 0.5
+    scale: '10m'
 
   # Settings for the plot's color bar
   colorbar:

--- a/ush/plotting/plot_mpas_netcdf.py
+++ b/ush/plotting/plot_mpas_netcdf.py
@@ -128,10 +128,12 @@ def plotit(config_d: dict,uxds: ux.UxDataset,filepath: str) -> None:
                     elif config_d["plot"]["boundaries"]["detail"]==1:
                         name='admin_1_states_provinces'
                     elif config_d["plot"]["boundaries"]["detail"]==2:
-                        name='admin_1_states_provinces'
+                        logging.debug("Counties only available at 10m resolution, overwriting scale=10m")
+                        config_d["plot"]["boundaries"]["scale"]='10m'
+                        name='admin_2_counties'
                     else:
                         raise ValueError(f'Invalid value for {config_d["plot"]["boundaries"]["detail"]=}')
-                    ax.add_feature(cfeature.NaturalEarthFeature(category='cultural', scale='50m', facecolor='none', linewidth=0.2, name=name))
+                    ax.add_feature(cfeature.NaturalEarthFeature(category='cultural', scale=config_d["plot"]["boundaries"]["scale"], facecolor='none', linewidth=0.2, name=name))
 
             # Create a dict of substitutable patterns to make string substitutions easier
             # using the python string builtin method format_map()

--- a/ush/plotting/plot_mpas_netcdf.py
+++ b/ush/plotting/plot_mpas_netcdf.py
@@ -99,6 +99,8 @@ def plotit(config_d: dict,uxds: ux.UxDataset,filepath: str) -> None:
             for lev in levs:
                 logging.debug(f"For level {lev}, data slice to plot:\n{sliced[lev]}")
                 if config_d["plot"]["periodic_bdy"]:
+                    logging.info("Creating polycollection with periodic_bdy=True")
+                    logging.info("NOTE: This option can be very slow for large domains")
                     pc=sliced[lev].to_polycollection(periodic_elements='split')
                 else:
                     pc=sliced[lev].to_polycollection()
@@ -106,11 +108,10 @@ def plotit(config_d: dict,uxds: ux.UxDataset,filepath: str) -> None:
                 pc.set_antialiased(False)
 
                 pc.set_cmap(config_d["plot"]["colormap"])
+                pc.set_clim(config_d["plot"]["vmin"],config_d["plot"]["vmax"])
 
-#            logging.info(f"Timer 4 {time.time()-start}")
                 fig, ax = plt.subplots(1, 1, figsize=(config_d["plot"]["figwidth"], config_d["plot"]["figheight"]),
                                    dpi=config_d["plot"]["dpi"], constrained_layout=True)
-#            logging.info(f"Timer 5 {time.time()-start}")
 
 
                 ax.set_xlim((config_d["plot"]["lonrange"][0],config_d["plot"]["lonrange"][1]))
@@ -144,7 +145,8 @@ def plotit(config_d: dict,uxds: ux.UxDataset,filepath: str) -> None:
                     cbar = plt.colorbar(coll,ax=ax,orientation=cb["orientation"])
                     if cb.get("label"):
                         cbar.set_label(cb["label"].format_map(patterns))
-    
+
+  
                 outfile=config_d["plot"]["filename"].format_map(patterns)
                 # Make sure any subdirectories exist before we try to write the file
                 logging.debug(f"Saving plot {outfile}")
@@ -272,7 +274,6 @@ if __name__ == "__main__":
     for f in files:
         # Open specified file and load dataset
         dataset=load_dataset(f,expt_config["data"]["gridfile"])
-
 
         # Make the plots!
         plotit(expt_config,dataset,f)

--- a/ush/plotting/plot_mpas_netcdf.py
+++ b/ush/plotting/plot_mpas_netcdf.py
@@ -121,7 +121,7 @@ def plotit(config_d: dict,uxds: ux.UxDataset,filepath: str) -> None:
 
                 #Plot coastlines if requested
                 if config_d["plot"]["coastlines"]:
-                    ax.add_feature(cfeature.COASTLINE)
+                    ax.add_feature(cfeature.NaturalEarthFeature(category='physical', **config_d["plot"]["coastlines"], name='coastline'))
                 if config_d["plot"]["boundaries"]:
                     if config_d["plot"]["boundaries"]["detail"]==0:
                         name='admin_0_countries'

--- a/ush/plotting/plot_mpas_netcdf.py
+++ b/ush/plotting/plot_mpas_netcdf.py
@@ -13,6 +13,8 @@ import time
 print("Importing uxarray; this may take a while...")
 import uxarray as ux
 import matplotlib.pyplot as plt
+import cartopy.feature as cfeature
+import cartopy.crs as ccrs
 
 import uwtools.api.config as uwconfig
 
@@ -111,15 +113,16 @@ def plotit(config_d: dict,uxds: ux.UxDataset,filepath: str) -> None:
                 pc.set_clim(config_d["plot"]["vmin"],config_d["plot"]["vmax"])
 
                 fig, ax = plt.subplots(1, 1, figsize=(config_d["plot"]["figwidth"], config_d["plot"]["figheight"]),
-                                   dpi=config_d["plot"]["dpi"], constrained_layout=True)
+                                   dpi=config_d["plot"]["dpi"], constrained_layout=True, subplot_kw=dict(projection=ccrs.PlateCarree()))
 
 
                 ax.set_xlim((config_d["plot"]["lonrange"][0],config_d["plot"]["lonrange"][1]))
                 ax.set_ylim((config_d["plot"]["latrange"][0],config_d["plot"]["latrange"][1]))
 
-            # add geographic features
-        #    ax.add_feature(cfeature.COASTLINE)
-        #    ax.add_feature(cfeature.BORDERS)
+                #Plot coastlines if requested
+                if config_d["plot"]["coastlines"]:
+                    ax.coastlines(**config_d["plot"]["coastlines"])
+
 
             # Create a dict of substitutable patterns to make string substitutions easier
             # using the python string builtin method format_map()
@@ -146,7 +149,6 @@ def plotit(config_d: dict,uxds: ux.UxDataset,filepath: str) -> None:
                     if cb.get("label"):
                         cbar.set_label(cb["label"].format_map(patterns))
 
-  
                 outfile=config_d["plot"]["filename"].format_map(patterns)
                 # Make sure any subdirectories exist before we try to write the file
                 logging.debug(f"Saving plot {outfile}")

--- a/ush/plotting/plot_mpas_netcdf.py
+++ b/ush/plotting/plot_mpas_netcdf.py
@@ -121,8 +121,17 @@ def plotit(config_d: dict,uxds: ux.UxDataset,filepath: str) -> None:
 
                 #Plot coastlines if requested
                 if config_d["plot"]["coastlines"]:
-                    ax.coastlines(**config_d["plot"]["coastlines"])
-
+                    ax.add_feature(cfeature.COASTLINE)
+                if config_d["plot"]["boundaries"]:
+                    if config_d["plot"]["boundaries"]["detail"]==0:
+                        name='admin_0_countries'
+                    elif config_d["plot"]["boundaries"]["detail"]==1:
+                        name='admin_1_states_provinces'
+                    elif config_d["plot"]["boundaries"]["detail"]==2:
+                        name='admin_1_states_provinces'
+                    else:
+                        raise ValueError(f'Invalid value for {config_d["plot"]["boundaries"]["detail"]=}')
+                    ax.add_feature(cfeature.NaturalEarthFeature(category='cultural', scale='50m', facecolor='none', linewidth=0.2, name=name))
 
             # Create a dict of substitutable patterns to make string substitutions easier
             # using the python string builtin method format_map()


### PR DESCRIPTION
**Synopsis**

Adding new options for plotting. All of these sit under the `plot:` section of the config file.

```
  # vmin, vmax:
  # By default the color range will be scaled to the max/min values of the plotted data. To use a custom range,
  # set vmin and/or vmax
  vmin: null
  vmax: null

  # Settings for plotting political boundaries. To disable political boundaries, specify "boundaries:" with no options
  boundaries:
    detail: 0

  # Settings for plotting coastlines. To disable coastlines, specify "coastlines:" with no options
  coastlines:
    # Scale is the resolution of the plotted boundary dataset. Options are 110m, 50m, and 10m.
    scale: '10m'
    # Most standard Matplotlib arguments for shapes will work here, but I haven't figured out good documentation on which.
    # The ones listed here work, but likely a lot more customization can happen here.
    color: 'black'
    linewidth: 0.5
    facecolor: 'none'
```

Here is an example plot produced with the following settings on Hera:
```
data:
  filename: /scratch1/BMC/hmtb/kavulich/MPAS/plotting_scripts/debby/history.2024-08-08_12.00.00.nc
  var:
    - qv
  lev:
    - 15
plot:
  filename: 'boundary_tests/cropped_{fnme}_{var}_{lev}_counties.png'
  title: 'Plot of {varln}, for MPAS forecast, {date} {time}'
  latrange:
    - 20
    - 40
  lonrange:
    - -100
    - -60
  boundaries:
    detail: 2
  colorbar:
    orientation: vertical
    label: 'Units: {units}'
  vmin: 0
  colormap: "viridis"
  coastlines:
    color: 'black'
    scale: '50m'
  dpi: 300
  figheight: 4
  figwidth: 8
```
![Screenshot 2024-12-19 at 2 41 24 PM](https://github.com/user-attachments/assets/f249f0de-3369-44ff-90bc-7c597ea9f4f1)


**Type**

- [x] Enhancement (adds new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.